### PR TITLE
refactor(logger): move logger instance and config to logging.py

### DIFF
--- a/app/api/routes/v1/ping_route.py
+++ b/app/api/routes/v1/ping_route.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.core.config import logger
+from app.core.logging import logger
 
 router = APIRouter()
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,13 +1,8 @@
 import logging
-import sys
 
 from databases import DatabaseURL
-from loguru import logger
 from starlette.config import Config
 from starlette.datastructures import Secret
-
-from .logging import format_record
-from .logging import InterceptHandler
 
 config = Config('.env')
 
@@ -29,20 +24,3 @@ DATABASE_URL = config(
 DEBUG: bool = config('DEBUG', cast=bool, default=False)
 
 LOGGING_LEVEL = logging.DEBUG if DEBUG else logging.INFO
-LOGGERS = ('uvicorn.asgi', 'uvicorn.access', 'uvicorn')
-
-logging.getLogger().handlers = [InterceptHandler()]
-for logger_name in LOGGERS:
-    logging_logger = logging.getLogger(logger_name)
-    logging_logger.handlers = [InterceptHandler(level=LOGGING_LEVEL)]
-
-# set format
-logger.configure(
-    handlers=[{'sink': sys.stdout,
-               'level': LOGGING_LEVEL, 'format': format_record}]
-)
-
-diagnose = True if DEBUG else False  # avoid leaking sensitive data in production
-# save logs to disk
-logger.add('log/access.log', format=format_record, enqueue=True, backtrace=True,
-           diagnose=diagnose, compression='zip', rotation='10 MB', retention='1 month')

--- a/app/db/tasks.py
+++ b/app/db/tasks.py
@@ -4,7 +4,7 @@ from databases import Database
 from fastapi import FastAPI
 
 from app.core.config import DATABASE_URL
-from app.core.config import logger
+from app.core.logging import logger
 
 
 async def connect_to_db(app: FastAPI) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes.v1 import api_v1
 from app.core import config
+from app.core import logging
 from app.core import tasks
 
 

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,7 +1,7 @@
 import pytest
 from httpx import AsyncClient
 
-from app.core.config import logger
+from app.core.logging import logger
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
moví la configuracion del logger y el logger mismo a app.core.logging, me pareció mas intuitivo importarlo desde ahí.

En app.main lo importo solo para que se corra el codigo y así se configure el logger para q fastapi lo use. No sé si es buena práctica importar algo para que el codigo se ejecute sin usar explícitamente lo que esta adentro, pero me pareció mejor que tener el logger en config.py, y dejar este último solo para variables de entorno.