### PR TITLE
fix(environment): fix env variable handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
+POSTGRES_LOCAL_PORT= # optional, to modify container published port
 
 # fastapi
 ENVIRONMENT=

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,13 +8,13 @@ config = Config('.env')
 PROJECT_NAME = 'V-Solar backend'
 VERSION = '0.1.0'
 
+POSTGRES_DB: str = config('POSTGRES_DB', cast=str)
 POSTGRES_USER: str = config('POSTGRES_USER', cast=str)
 POSTGRES_PASSWORD: Secret = config('POSTGRES_PASSWORD', cast=Secret)
-POSTGRES_SERVER: str = config('POSTGRES_SERVER', cast=str, default='db')
+POSTGRES_HOST: str = config('POSTGRES_HOST', cast=str)
 POSTGRES_PORT: str = config('POSTGRES_PORT', cast=str, default='5432')
-POSTGRES_DB: str = config('POSTGRES_DB', cast=str)
 
-DATABASE_URL = f'postgresql+asyncpg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_SERVER}:{POSTGRES_PORT}/{POSTGRES_DB}'
+DATABASE_URL = f'postgresql+asyncpg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}'
 
 DEBUG: bool = config('DEBUG', cast=bool, default=False)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,13 @@ services:
     image: postgres
     restart: unless-stopped
     environment:
-      - POSTGRES_USER:-postgres
-      - POSTGRES_PASSWORD:-postgres
-      - POSTGRES_DB:-postgres
-    env_file: .env
+      POSTGRES_DB: ${POSTGRES_DB-postgres}
+      POSTGRES_USER: ${POSTGRES_USER-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD-postgres}
     volumes:
       - dbdata:/var/lib/postgresql/data
     ports:
-      - 54432:5432
+      - ${POSTGRES_LOCAL_PORT-5432}:5432
 
   pgadmin:
     image: dpage/pgadmin4
@@ -32,11 +31,15 @@ services:
       args:
         - INSTALL_DEV=${INSTALL_DEV:-false}
     restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB-postgres}
+      POSTGRES_USER: ${POSTGRES_USER-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD-postgres}
+      POSTGRES_HOST: ${POSTGRES_HOST-db}
     depends_on:
       - db
     command: sh -c "poetry run alembic upgrade head &&
       poetry run uvicorn app.asgi:app --reload --reload-dir app --log-level debug --host 0.0.0.0 --port 8000"
-    env_file: .env
     ports:
       - 3001:8000
     volumes:


### PR DESCRIPTION
Arreglé unos errores de syntaxis en el compose file
con las variables de entorno. También removí los defaults
del config file de la api porque hacia más sentido tener esos defaults
en el compose file, asi en producción cuando no ocupemos el compose file
nos tire error si no tenemos las variables en el servidor. Agregué
tambien una variable opcional para cambiar el puerto al que se bindea en
el host el contenedor de postgres.