### PR TITLE
fix(compose): default env syntax

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,11 +4,11 @@ services:
   db:
     image: postgres
     environment:
-      POSTGRES_DB: ${POSTGRES_DB-postgres}
-      POSTGRES_USER: ${POSTGRES_USER-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
-      - ${POSTGRES_LOCAL_PORT-5432}:5432
+      - 5432:5432
 
   api:
     build:
@@ -16,10 +16,10 @@ services:
       args:
         - INSTALL_DEV=true
     environment:
-      POSTGRES_DB: ${POSTGRES_DB-postgres}
-      POSTGRES_USER: ${POSTGRES_USER-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD-postgres}
-      POSTGRES_HOST: ${POSTGRES_HOST-db}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
     depends_on:
       - db
     command: sh -c "poetry run pytest -v -s"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,14 @@ services:
     image: postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ${POSTGRES_DB-postgres}
-      POSTGRES_USER: ${POSTGRES_USER-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     env_file: .env
     volumes:
       - dbdata:/var/lib/postgresql/data
     ports:
-      - ${POSTGRES_LOCAL_PORT-5432}:5432
+      - ${POSTGRES_LOCAL_PORT:-5432}:5432
 
   pgadmin:
     image: dpage/pgadmin4
@@ -31,14 +31,14 @@ services:
     build:
       context: .
       args:
-        - INSTALL_DEV=${INSTALL_DEV:-false}
+        - INSTALL_DEV=${INSTALL_DEV:-true}
     restart: unless-stopped
     env_file: .env
     environment:
-      POSTGRES_DB: ${POSTGRES_DB-postgres}
-      POSTGRES_USER: ${POSTGRES_USER-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD-postgres}
-      POSTGRES_HOST: ${POSTGRES_HOST-db}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
     depends_on:
       - db
     command: sh -c "poetry run alembic upgrade head &&


### PR DESCRIPTION
la sintaxis con solo el "-" funcionaba, pero es
mas robusta la con el ":-" (contexto: https://stackoverflow.com/\
questions/33784730/fallback-for-environment-variables-with-docker-compose).
también dejé install_dev como true por defecto, asi es mas llegar
y ocupar, y las variables de entorno son opcionales. En producción
es mala idea pero igual ocuparemos otro compose file de todas formas,
asi que da igual. También saqué la opcion de cambiar el puerto en el
host para postgres, no tiene sentido si es solo para cd/ci.